### PR TITLE
syntax error, use $::operatingsystem for top-level variables.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,122 +1,122 @@
-
+# Parameter file for nsswitch.
 class nsswitch::params {
 
-	case $operatingsystem {
-	
-		/(?i:Debian)/: {
-			
-			$package = [ 'nscd', 'libnss-ldap' ]
-			
-			$owner    = 'root'
-			$group    = 'root'
-			$config   = "/etc/nsswitch.conf"
-			$ldap_cfg = '/etc/ldap/ldap.conf'
-			$libnss   = "/etc/libnss-ldap.conf"
-			
-			$service     = 'nscd'
-			$script      = 'nscd'
-			$pattern     = 'nscd'
-			$service_cfg = $config
+  case $::operatingsystem {
+  
+    /(?i:Debian)/: {
+      
+      $package = [ 'nscd', 'libnss-ldap' ]
+      
+      $owner    = 'root'
+      $group    = 'root'
+      $config   = '/etc/nsswitch.conf'
+      $ldap_cfg = '/etc/ldap/ldap.conf'
+      $libnss   = '/etc/libnss-ldap.conf'
+      
+      $service     = 'nscd'
+      $script      = 'nscd'
+      $pattern     = 'nscd'
+      $service_cfg = $config
 
-			$databases_ldap = [ 
-				'set *[self::database = "passwd"]/service[1] compat',
-				'set *[self::database = "passwd"]/service[2] ldap',
-				'set *[self::database = "shadow"]/service[1] compat',
-				'set *[self::database = "shadow"]/service[2] ldap',
-				'set *[self::database = "group" ]/service[1] compat',
-				'set *[self::database = "group" ]/service[2] ldap',
-				]
+      $databases_ldap = [ 
+        'set *[self::database = "passwd"]/service[1] compat',
+        'set *[self::database = "passwd"]/service[2] ldap',
+        'set *[self::database = "shadow"]/service[1] compat',
+        'set *[self::database = "shadow"]/service[2] ldap',
+        'set *[self::database = "group" ]/service[1] compat',
+        'set *[self::database = "group" ]/service[2] ldap',
+        ]
 
-			$databases_none = [
-				'set *[self::database = "passwd"]/service[1] compat',
-				'set *[self::database = "shadow"]/service[1] compat',
-				'set *[self::database = "group" ]/service[1] compat',
-				]
-		}
+      $databases_none = [
+        'set *[self::database = "passwd"]/service[1] compat',
+        'set *[self::database = "shadow"]/service[1] compat',
+        'set *[self::database = "group" ]/service[1] compat',
+        ]
+    }
 
-		/(?i:Redhat|CentOS)/: {
-			$mod_prefix = 'nsswitch/redhat'
-			
-			$prefix = '/etc'
-			$owner  = 'root'
-			$group  = 'root'
+    /(?i:Redhat|CentOS)/: {
+      $mod_prefix = 'nsswitch/redhat'
+      
+      $prefix = '/etc'
+      $owner  = 'root'
+      $group  = 'root'
 
-			$config = "${prefix}/nsswitch.conf"
+      $config = "${prefix}/nsswitch.conf"
 
-			if($operatingsystemrelease =~ /^6\./) {
+      if($::operatingsystemrelease =~ /^6\./) {
 
-				$package = [ 'nscd', ]
-			
-				$config_src  = "${prefix}/nsswitch.conf-6.x"
-				
-				$service     = 'nslcd'
-				$script      = 'nslcd'
-				$pattern     = 'nslcd'
-				$service_cfg = "${prefix}/nslcd.conf"
+        $package = [ 'nscd', ]
+      
+        $config_src  = "${prefix}/nsswitch.conf-6.x"
+        
+        $service     = 'nslcd'
+        $script      = 'nslcd'
+        $pattern     = 'nslcd'
+        $service_cfg = "${prefix}/nslcd.conf"
 
-				$databases_ldap = [ 
-					'set *[self::database = "passwd"]/service[1] files',
-					'set *[self::database = "passwd"]/service[2] sss',
-					'set *[self::database = "shadow"]/service[1] files',
-					'set *[self::database = "shadow"]/service[2] sss',
-					'set *[self::database = "group" ]/service[1] files',
-					'set *[self::database = "group" ]/service[2] sss',
-					]
+        $databases_ldap = [ 
+          'set *[self::database = "passwd"]/service[1] files',
+          'set *[self::database = "passwd"]/service[2] sss',
+          'set *[self::database = "shadow"]/service[1] files',
+          'set *[self::database = "shadow"]/service[2] sss',
+          'set *[self::database = "group" ]/service[1] files',
+          'set *[self::database = "group" ]/service[2] sss',
+          ]
 
-				$databases_none = [
-					'set *[self::database = "passwd"]/service[1] files',
-					'set *[self::database = "shadow"]/service[1] files',
-					'set *[self::database = "group" ]/service[1] files',
-					]
+        $databases_none = [
+          'set *[self::database = "passwd"]/service[1] files',
+          'set *[self::database = "shadow"]/service[1] files',
+          'set *[self::database = "group" ]/service[1] files',
+          ]
 
-			} else {
+      } else {
 
-				$package = [ 
+        $package = [ 'nss_ldap' ]
 
-				$config_src  = "${prefix}/nsswitch.conf-5.x"
+        $config_src  = "${prefix}/nsswitch.conf-5.x"
 
-				$service     = 'nscd'
-				$script      = 'nscd'
-				$pattern     = 'nscd'
-				$service_cfg = "${prefix}/nsswitch.conf"
-				$service_pkg = 'nscd'
+        $service     = 'nscd'
+        $script      = 'nscd'
+        $pattern     = 'nscd'
+        $service_cfg = "${prefix}/nsswitch.conf"
+        $service_pkg = 'nscd'
 
-				$databases_ldap = [ 
-					'set *[self::database = "passwd"]/service[1] files',
-					'set *[self::database = "passwd"]/service[2] ldap',
-					'set *[self::database = "shadow"]/service[1] files',
-					'set *[self::database = "shadow"]/service[2] ldap',
-					'set *[self::database = "group" ]/service[1] files',
-					'set *[self::database = "group" ]/service[2] ldap',
-					]
+        $databases_ldap = [ 
+          'set *[self::database = "passwd"]/service[1] files',
+          'set *[self::database = "passwd"]/service[2] ldap',
+          'set *[self::database = "shadow"]/service[1] files',
+          'set *[self::database = "shadow"]/service[2] ldap',
+          'set *[self::database = "group" ]/service[1] files',
+          'set *[self::database = "group" ]/service[2] ldap',
+          ]
 
-				$databases_none = [
-					'set *[self::database = "passwd"]/service[1] files',
-					'set *[self::database = "shadow"]/service[1] files',
-					'set *[self::database = "group" ]/service[1] files',
-					]
-			}
-		}
-	
-		/(?i:OpenSuSE|SLES)/: {
-			
-			$package = [ 'nscd', 'nss_ldap' ]
-			
-			$owner    = 'root'
-			$group    = 'root'
-			$config   = "/etc/nsswitch.conf"
-			$ldap_cfg = '/etc/ldap/ldap.conf'
-			$libnss   = "/etc/libnss-ldap.conf"
-			
-			$service     = 'nscd'
-			$script      = 'nscd'
-			$pattern     = 'nscd'
-			$service_cfg = $config
+        $databases_none = [
+          'set *[self::database = "passwd"]/service[1] files',
+          'set *[self::database = "shadow"]/service[1] files',
+          'set *[self::database = "group" ]/service[1] files',
+          ]
+      }
+    }
+  
+    /(?i:OpenSuSE|SLES)/: {
+      
+      $package = [ 'nscd', 'nss_ldap' ]
+      
+      $owner    = 'root'
+      $group    = 'root'
+      $config   = "/etc/nsswitch.conf"
+      $ldap_cfg = '/etc/ldap/ldap.conf'
+      $libnss   = "/etc/libnss-ldap.conf"
+      
+      $service     = 'nscd'
+      $script      = 'nscd'
+      $pattern     = 'nscd'
+      $service_cfg = $config
 
-		}
+    }
 
-		default: {
-			fail("Operating system ${::operatingsystem} not supported")
-		}
-	}
+    default: {
+      fail("Operating system ${::operatingsystem} not supported")
+    }
+  }
 }


### PR DESCRIPTION
Seeing this error:

_err: Could not parse for environment production: Syntax error at '='; expected ']' at /puppet-environments/modules/nsswitch/manifests/params.pp:76
err: Try 'puppet help parser validate' for usage_

...and fixed.

I must be doing something different with tabs; sorry for that.
