### PR TITLE
Add sudoers support to nsswitch, also add Ubuntu to the support OS families

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,9 +3,9 @@ class nsswitch::params {
 
   case $::operatingsystem {
   
-    /(?i:Debian)/: {
+    /(?i:Debian|Ubuntu)/: {
       
-      $package = [ 'nscd', 'libnss-ldap' ]
+      $package = [ 'nscd', 'libnss-ldap', 'sudo-ldap' ]
       
       $owner    = 'root'
       $group    = 'root'
@@ -25,6 +25,8 @@ class nsswitch::params {
         'set *[self::database = "shadow"]/service[2] ldap',
         'set *[self::database = "group" ]/service[1] compat',
         'set *[self::database = "group" ]/service[2] ldap',
+	'set *[self::database = "sudoers" ]/service[1] compat',
+	'set *[self::database = "sudoers" ]/service[2] ldap'
         ]
 
       $databases_none = [

--- a/templates/nsswitch.conf.erb
+++ b/templates/nsswitch.conf.erb
@@ -11,6 +11,7 @@
 passwd:         files <% if module_type == 'ldap' then %>ldap<% end %>
 group:          files <% if module_type == 'ldap' then %>ldap<% end %>
 shadow:         files <% if module_type == 'ldap' then %>ldap<% end %>
+sudoers:        <% if module_type == 'ldap' then %>ldap<% end%> files
 
 hosts:          files dns
 networks:       files


### PR DESCRIPTION
See summary. I haven't tested the sudo support with any other OS families, just Debian/Ubuntu.
